### PR TITLE
Initialize CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,51 @@
+name: Rust CI/CD
+
+# 1) CI: on pushes & PRs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  # 2) CD: on new version tags
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  ci:
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      
+      - name: Build
+        run: cargo build
+
+      - name: Run tests
+        run: cargo test --all-features
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    name: Release on Tag
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Build release
+        run: cargo build --release


### PR DESCRIPTION
Add a CI that runs on every
- push to `main` branch
- PR to `main` branch

Add a CD that runs on every release of new tag

CI workflow:
- Build with `cargo build`
- Test with `cargo test --all-features`

CD workflow:
- Build with `cargo build --release`