### PR TITLE
Add line numbers, count, invert

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -29,6 +29,10 @@ pub struct Args {
     #[arg(short = 'c', long, action = ArgAction::SetTrue)]
     pub count: bool,
 
+    /// Invert match: show lines that *do not* match
+    #[arg(short = 'v', long, action = ArgAction::SetTrue)]
+    pub invert: bool,
+
     /// Number of context lines to show before and after each match
     #[arg(short = 'C', long, default_value_t = 0, value_name = "NUM")]
     pub context: usize,

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,15 @@
+use crate::args::Args;
+
+pub fn print_matches(matches: &[(usize, &str)], args: &Args) {
+    if args.count {
+        println!("Match count: {}", matches.len());
+        return;
+    }
+
+    for &(idx, line) in matches {
+        if args.show_line_numbers {
+            print!("{:>6}  ", idx + 1);
+        }
+        println!("{}", line);
+    }
+}


### PR DESCRIPTION
Make a richer CLI by adding these features:
- Flag `-n` to show line numbers
- Flag `-c` to show only counts
- Flag `-v` to show inverted matches

Restructured the search functions to a single section taking a prepared matcher closure and passing the results to a printer function.