### PR TITLE
Enable search with context

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -37,6 +37,14 @@ pub struct Args {
     #[arg(short = 'C', long, default_value_t = 0, value_name = "NUM")]
     pub context: usize,
 
+    /// Number of lines **after** each match to include
+    #[arg(short = 'A', long, default_value_t = 0, value_name = "NUM")]
+    pub context_after: usize,
+
+    /// Number of lines **before** each match to include
+    #[arg(short = 'B', long, default_value_t = 0, value_name = "NUM")]
+    pub context_before: usize,
+
     /// Treat query as a regular expression
     #[arg(short = 'E', long, action = ArgAction::SetTrue)]
     pub regex: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::io;
 use std::error::Error;
+use std::cmp::min;
+use std::collections::HashSet;
 
 use regex::Regex;
 
@@ -8,7 +10,7 @@ pub mod args;
 use args::Args;
 
 pub mod output;
-use output::print_matches;
+use output::{print_matches, print_matches_with_context};
 
 pub fn run(args: &Args) -> Result<(), Box<dyn Error>> {
     let contents = if args.path == "-" {
@@ -16,7 +18,7 @@ pub fn run(args: &Args) -> Result<(), Box<dyn Error>> {
     } else {
         fs::read_to_string(&args.path)?
     };
-
+    
     let matcher = |line: &str| {
         let hit = if args.regex {
             Regex::new(&args.query).unwrap().is_match(line)
@@ -27,6 +29,29 @@ pub fn run(args: &Args) -> Result<(), Box<dyn Error>> {
         };
         if args.invert { !hit } else { hit }
     };
+    
+    if args.context != 0 {
+        let lines: Vec<&str> = contents.lines().collect();
+
+        let match_idxs: Vec<usize> = lines
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &line)| if matcher(line) { Some(i) } else { None })
+            .collect();
+        
+        let mut context_set = HashSet::new();
+        for &i in &match_idxs {
+            let start = i.saturating_sub(args.context);
+            let end = min(i + args.context, lines.len().saturating_sub(1));
+            for j in start..=end {
+                context_set.insert(j);
+            }
+        }
+
+        print_matches_with_context(&lines, &match_idxs, &context_set, args);
+
+        return Ok(());
+    }
 
     let matches: Vec<(usize, &str)> = contents
         .lines()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub fn run(args: &Args) -> Result<(), Box<dyn Error>> {
         if args.invert { !hit } else { hit }
     };
     
-    if args.context != 0 {
+    if (args.context, args.context_after, args.context_before) != (0, 0, 0) {
         let lines: Vec<&str> = contents.lines().collect();
 
         let match_idxs: Vec<usize> = lines
@@ -39,10 +39,13 @@ pub fn run(args: &Args) -> Result<(), Box<dyn Error>> {
             .filter_map(|(i, &line)| if matcher(line) { Some(i) } else { None })
             .collect();
         
+        let after = if args.context > 0 { args.context } else { args.context_after };
+        let before = if args.context > 0 { args.context } else { args.context_before };
+        
         let mut context_set = HashSet::new();
         for &i in &match_idxs {
-            let start = i.saturating_sub(args.context);
-            let end = min(i + args.context, lines.len().saturating_sub(1));
+            let start = i.saturating_sub(before);
+            let end = min(i + after, lines.len().saturating_sub(1));
             for j in start..=end {
                 context_set.insert(j);
             }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use crate::args::Args;
 
 pub fn print_matches(matches: &[(usize, &str)], args: &Args) {
@@ -11,5 +12,41 @@ pub fn print_matches(matches: &[(usize, &str)], args: &Args) {
             print!("{:>6}  ", idx + 1);
         }
         println!("{}", line);
+    }
+}
+
+pub fn print_matches_with_context(
+    lines: &[&str], 
+    match_idxs: &[usize], 
+    context_set: &HashSet<usize>,
+    args: &Args
+) {
+    let mut prev: Option<usize> = None;
+    let match_set: HashSet<usize> = match_idxs.iter().copied().collect();
+
+    for (i, &line) in lines.iter().enumerate() {
+        if !context_set.contains(&i) {
+            continue;
+        }
+
+        // Insert separator if there’s a gap
+        if let Some(last) = prev {
+            if i > last + 1 {
+                println!("--");
+            }
+        }
+
+        // Choose prefix: '>' for match, '|' for context
+        let prefix = if match_set.contains(&i) { '>' } else { '|' };
+
+        // Optional line numbers
+        if args.show_line_numbers {
+            // +1 because `enumerate` is zero-based
+            println!("{} {:>4}: {}", prefix, i + 1, line);
+        } else {
+            println!("{} {}", prefix, line);
+        }
+
+        prev = Some(i);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -39,9 +39,7 @@ pub fn print_matches_with_context(
         // Choose prefix: '>' for match, '|' for context
         let prefix = if match_set.contains(&i) { '>' } else { '|' };
 
-        // Optional line numbers
         if args.show_line_numbers {
-            // +1 because `enumerate` is zero-based
             println!("{} {:>4}: {}", prefix, i + 1, line);
         } else {
             println!("{} {}", prefix, line);


### PR DESCRIPTION
This PR introduces a support for searching with context, using the flag `-C`/`--context`, `-A`/`--context_after`, `-B`/`--context_before` 

Example usage:
- `minigrep.exe -C 2 --query error --path logfile.txt` will also print two lines before and after every match lines
- `minigrep.exe -A 1 -B 2 --query error --path logfile.txt` will also print two lines before and one line after every match lines

Note:
- the `-C` flag overrides any `-A` and `-B` flags