### PR TITLE
add fuzzy search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +232,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
+ "fuzzy-matcher",
  "ignore",
  "regex",
 ]
@@ -318,6 +334,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ clap = { version = "4.2", features = ["derive"] }
 regex = "1"
 ignore = "0.4"
 colored = "2"
+fuzzy-matcher = "0.3"

--- a/src/args.rs
+++ b/src/args.rs
@@ -60,4 +60,12 @@ pub struct Args {
     /// Colorize matching text
     #[arg(long, action = ArgAction::SetTrue)]
     pub color: bool,
+
+    /// Use fuzzy matching instead of exact substring/regex
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub fuzzy: bool,
+
+    /// Minimum fuzzy score to accept (higher implies stricter)
+    #[arg(long, default_value_t = 1, value_name = "SCORE")]
+    pub fuzzy_threshold: i64,
 }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,0 +1,53 @@
+use regex::Regex;
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use crate::args::Args;
+
+pub enum MatcherKind {
+    Exact(String),
+    CaseInsensitive(String),
+    Regex(Regex),
+    Fuzzy(String, SkimMatcherV2, i64),
+}
+
+pub struct Matcher {
+    kind: MatcherKind,
+    invert: bool,
+}
+
+impl Matcher {
+    /// Create a Matcher from CLI arguments, capturing both strategy and inversion.
+    pub fn new(args: &Args) -> Self {
+        let kind = if args.fuzzy {
+            MatcherKind::Fuzzy(
+                args.query.clone(),
+                SkimMatcherV2::default(),
+                args.fuzzy_threshold,
+            )
+        } else if args.regex {
+            MatcherKind::Regex(Regex::new(&args.query).unwrap())
+        } else if args.ignore_case {
+            MatcherKind::CaseInsensitive(args.query.to_lowercase())
+        } else {
+            MatcherKind::Exact(args.query.clone())
+        };
+        Matcher { kind, invert: args.invert }
+    }
+
+    /// Test whether the given line matches according to the chosen strategy,
+    /// applying inversion if requested.
+    pub fn is_match(&self, line: &str) -> bool {
+        let hit = match &self.kind {
+            MatcherKind::Exact(q) => line.contains(q),
+            MatcherKind::CaseInsensitive(q) => line.to_lowercase().contains(q),
+            MatcherKind::Regex(re) => re.is_match(line),
+            MatcherKind::Fuzzy(query, matcher, threshold) => {
+                matcher
+                    .fuzzy_match(line, query)
+                    .filter(|&score| score >= *threshold)
+                    .is_some()
+            }
+        };
+        if self.invert { !hit } else { hit }
+    }
+}


### PR DESCRIPTION
- Fuzzy matching (`--fuzzy`, `--fuzzy‑threshold`) powered by `fuzzy-matcher`.
- Refactored all match logic into a single `Matcher` type (exact, CI, regex, fuzzy, `-v`).