### PR TITLE
support multiple patterns

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -10,8 +10,8 @@ use clap::{Parser, ArgAction};
 )]
 pub struct Args {
     /// The pattern to look for
-    #[arg(short, long, value_name = "PATTERN")]
-    pub query: String,
+    #[arg(short = 'e', long, value_name = "PATTERN", num_args = 1..)]
+    pub query: Vec<String>,
 
     /// File or directory to search (use "-" or omit for stdin)
     #[arg(short, long, default_value = "-", value_name = "PATH")]


### PR DESCRIPTION
Multi-pattern & Regex Matching
- Modify the `query` argument to accept multiple patterns (Vec<String>)
- Compile each pattern into a Regex when `--regex` is set (with `--ignore-case` support)
- Literal, CI and fuzzy matchers now loop over all patterns and invert (`-v`) remains unchanged

Example usage for exact OR search:
`cargo run -- -e TODO -e FIXME --path src/`